### PR TITLE
fix parameter order in GetFirewallRule func

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -913,7 +913,7 @@ func (c *client) CreateFirewallRule(ctx context.Context, fwRule *api.FirewallRul
 	return retFwrule, nil
 }
 
-func (c *client) GetFirewallRule(ctx context.Context, ruleID string, interfaceID string, ignoredErrors ...errors.IgnoredErrors) (*api.FirewallRule, error) {
+func (c *client) GetFirewallRule(ctx context.Context, interfaceID string, ruleID string, ignoredErrors ...errors.IgnoredErrors) (*api.FirewallRule, error) {
 	res, err := c.DPDKonmetalClient.GetFirewallRule(ctx, &dpdkproto.GetFirewallRuleRequest{
 		InterfaceId: []byte(interfaceID),
 		RuleId:      []byte(ruleID),


### PR DESCRIPTION
Fixes #
Fix the order of parameters in GetFirewallRule function to match Interface definition.