### PR TITLE
Remove unused VirtualFunction fields

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -308,15 +308,7 @@ type InterfaceSpec struct {
 }
 
 type VirtualFunction struct {
-	Name     string `json:"name"`
-	Domain   uint32 `json:"domain"`
-	Bus      uint32 `json:"bus"`
-	Slot     uint32 `json:"slot"`
-	Function uint32 `json:"function"`
-}
-
-func (vf *VirtualFunction) String() string {
-	return fmt.Sprintf("Name: %s, Domain: %d, Bus: %d, Slot: %d, Function: %d", vf.Name, vf.Domain, vf.Bus, vf.Slot, vf.Function)
+	Name string `json:"name"`
 }
 
 type InterfaceList struct {

--- a/client/client.go
+++ b/client/client.go
@@ -377,11 +377,7 @@ func (c *client) CreateInterface(ctx context.Context, iface *api.Interface, igno
 	retInterface.Spec = iface.Spec
 	retInterface.Spec.UnderlayRoute = &underlayRoute
 	retInterface.Spec.VirtualFunction = &api.VirtualFunction{
-		Name:     res.Vf.Name,
-		Domain:   res.Vf.Domain,
-		Bus:      res.Vf.Bus,
-		Slot:     res.Vf.Slot,
-		Function: res.Vf.Function,
+		Name: res.Vf.Name,
 	}
 
 	return retInterface, nil


### PR DESCRIPTION
Removed VirtualFunction fields that are not used anymore.
Requested in [issue 444](https://github.com/ironcore-dev/dpservice/issues/444).

These fields are not used in metalnet, only in dpservice-cli (will be updated after merge).